### PR TITLE
Modular dimensions

### DIFF
--- a/Numeric/Units/Dimensional/DK/Dimensions.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions.hs
@@ -1,10 +1,19 @@
--- | Provides both term-level and type-level representations for physical dimensions in 
--- a single import for convenience.
---
--- Presuming that users intend to work primarily with type level dimensions, this module hides
--- arithmetic operators over term level dimensions and aliases for the base term-level dimensions
--- to avoid namespace pollution. These features are available directly from
--- "Numeric.Units.Dimensional.DK.Dimensions.TermLevel" if desired.
+{- |
+   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   License    : BSD3
+
+   Maintainer : bjorn@buckwalter.se
+   Stability  : Stable
+   Portability: GHC only
+
+Provides both term-level and type-level representations for physical dimensions in 
+a single import for convenience.
+
+Presuming that users intend to work primarily with type level dimensions, this module hides
+arithmetic operators over term level dimensions and aliases for the base term-level dimensions
+to avoid namespace pollution. These features are available directly from
+"Numeric.Units.Dimensional.DK.Dimensions.TermLevel" if desired.
+-}
 module Numeric.Units.Dimensional.DK.Dimensions
 (
   module Numeric.Units.Dimensional.DK.Dimensions.TermLevel,

--- a/Numeric/Units/Dimensional/DK/Dimensions.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions.hs
@@ -12,5 +12,5 @@ module Numeric.Units.Dimensional.DK.Dimensions
 )
 where
 
-import Numeric.Units.Dimensional.DK.Dimensions.TermLevel hiding ((*), (/), recip, dOne, dLength, dMass, dTime, dElectricCurrent, dThermodynamicTemperature, dAmountOfSubstance, dLuminousIntensity)
+import Numeric.Units.Dimensional.DK.Dimensions.TermLevel hiding ((*), (/), (^), recip, dOne, dLength, dMass, dTime, dElectricCurrent, dThermodynamicTemperature, dAmountOfSubstance, dLuminousIntensity)
 import Numeric.Units.Dimensional.DK.Dimensions.TypeLevel

--- a/Numeric/Units/Dimensional/DK/Dimensions.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions.hs
@@ -1,5 +1,10 @@
 -- | Provides both term-level and type-level representations for physical dimensions in 
 -- a single import for convenience.
+--
+-- Presuming that users intend to work primarily with type level dimensions, this module hides
+-- arithmetic operators over term level dimensions and aliases for the base term-level dimensions
+-- to avoid namespace pollution. These features are available directly from
+-- "Numeric.Units.Dimensional.DK.Dimensions.TermLevel" if desired.
 module Numeric.Units.Dimensional.DK.Dimensions
 (
   module Numeric.Units.Dimensional.DK.Dimensions.TermLevel,
@@ -7,5 +12,5 @@ module Numeric.Units.Dimensional.DK.Dimensions
 )
 where
 
-import Numeric.Units.Dimensional.DK.Dimensions.TermLevel
+import Numeric.Units.Dimensional.DK.Dimensions.TermLevel hiding ((*), (/), recip, dOne, dLength, dMass, dTime, dElectricCurrent, dThermodynamicTemperature, dAmountOfSubstance, dLuminousIntensity)
 import Numeric.Units.Dimensional.DK.Dimensions.TypeLevel

--- a/Numeric/Units/Dimensional/DK/Dimensions.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions.hs
@@ -1,0 +1,11 @@
+-- | Provides both term-level and type-level representations for physical dimensions in 
+-- a single import for convenience.
+module Numeric.Units.Dimensional.DK.Dimensions
+(
+  module Numeric.Units.Dimensional.DK.Dimensions.TermLevel,
+  module Numeric.Units.Dimensional.DK.Dimensions.TypeLevel
+)
+where
+
+import Numeric.Units.Dimensional.DK.Dimensions.TermLevel
+import Numeric.Units.Dimensional.DK.Dimensions.TypeLevel

--- a/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
@@ -11,7 +11,7 @@ module Numeric.Units.Dimensional.DK.Dimensions.TermLevel
 where
 
 import Data.Monoid (Monoid(..))
-import Prelude hiding ((*), (/), (^), recip)
+import Prelude (id, (+), (-), Int, Show, Eq, Ord)
 import qualified Prelude as P
 
 -- | A physical dimension, encoded as 7 integers, representing a factorization of the dimension into the

--- a/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
@@ -3,15 +3,25 @@ module Numeric.Units.Dimensional.DK.Dimensions.TermLevel
 (
   Dimension'(..),
   HasDimension(..),
+  dOne,
+  dLength, dMass, dTime, dElectricCurrent, dThermodynamicTemperature, dAmountOfSubstance, dLuminousIntensity,
+  (*), (/), recip,
   asList
 )
 where
+
+import Prelude hiding ((*), (/), recip)
 
 -- | A physical dimension, encoded as 7 integers, representing a factorization of the dimension into the
 -- 7 SI base dimensions. By convention they are stored in the same order as 
 -- in the 'Numeric.Units.Dimensional.DK.Dimensions.TypeLevel.Dimension' data kind.
 data Dimension' = Dim' !Int !Int !Int !Int !Int !Int !Int 
   deriving (Show, Eq, Ord)
+
+-- | The monoid of dimensions under multiplication.
+instance Monoid Dimension' where
+  mempty = dOne
+  mappend = (*)
 
 -- | Dimensional values inhabit this class, which allows access to a term-level representation of their dimension.
 class HasDimension a where 
@@ -20,6 +30,31 @@ class HasDimension a where
 
 instance HasDimension Dimension' where
   dimension = id
+
+-- | The dimension of dimensionless values.
+dOne :: Dimension'
+dOne = Dim' 0 0 0 0 0 0 0
+
+dLength, dMass, dTime, dElectricCurrent, dThermodynamicTemperature, dAmountOfSubstance, dLuminousIntensity :: Dimension'
+dLength                   = Dim' 1 0 0 0 0 0 0
+dMass                     = Dim' 0 1 0 0 0 0 0
+dTime                     = Dim' 0 0 1 0 0 0 0
+dElectricCurrent          = Dim' 0 0 0 1 0 0 0
+dThermodynamicTemperature = Dim' 0 0 0 0 1 0 0
+dAmountOfSubstance        = Dim' 0 0 0 0 0 1 0
+dLuminousIntensity        = Dim' 0 0 0 0 0 0 1
+
+-- | Forms the product of two dimensions.
+(*) :: Dimension' -> Dimension' -> Dimension'
+(Dim' l m t i th n j) * (Dim' l' m' t' i' th' n' j') = Dim' (l + l') (m + m') (t + t') (i + i') (th + th') (n + n') (j + j')
+
+-- | Forms the quotient of two dimensions.
+(/) :: Dimension' -> Dimension' -> Dimension'
+(Dim' l m t i th n j) / (Dim' l' m' t' i' th' n' j') = Dim' (l - l') (m - m') (t - t') (i - i') (th - th') (n - n') (j - j')
+
+-- | Forms the reciprocal of a dimension.
+recip :: Dimension' -> Dimension'
+recip = (dOne /)
 
 -- | Converts a dimension to a list of 7 integers, representing the exponent associated with each
 -- of the 7 SI base dimensions in the standard order.

--- a/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
@@ -64,6 +64,15 @@ dThermodynamicTemperature = Dim' 0 0 0 0 1 0 0
 dAmountOfSubstance        = Dim' 0 0 0 0 0 1 0
 dLuminousIntensity        = Dim' 0 0 0 0 0 0 1
 
+{-
+We will reuse the operators and function names from the Prelude.
+To prevent unpleasant surprises we give operators the same fixity
+as the Prelude.
+-}
+
+infixr 8  ^
+infixl 7  *, /
+
 -- | Forms the product of two dimensions.
 (*) :: Dimension' -> Dimension' -> Dimension'
 (Dim' l m t i th n j) * (Dim' l' m' t' i' th' n' j') = Dim' (l + l') (m + m') (t + t') (i + i') (th + th') (n + n') (j + j')

--- a/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
@@ -10,6 +10,7 @@ module Numeric.Units.Dimensional.DK.Dimensions.TermLevel
 )
 where
 
+import Data.Monoid (Monoid(..))
 import Prelude hiding ((*), (/), (^), recip)
 import qualified Prelude as P
 

--- a/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
@@ -1,0 +1,27 @@
+{-# OPTIONS_HADDOCK not-home, show-extensions #-}
+module Numeric.Units.Dimensional.DK.Dimensions.TermLevel
+(
+  Dimension'(..),
+  HasDimension(..),
+  asList
+)
+where
+
+-- | A physical dimension, encoded as 7 integers, representing a factorization of the dimension into the
+-- 7 SI base dimensions. By convention they are stored in the same order as 
+-- in the 'Numeric.Units.Dimensional.DK.Dimensions.TypeLevel.Dimension' data kind.
+data Dimension' = Dim' !Int !Int !Int !Int !Int !Int !Int 
+  deriving (Show, Eq, Ord)
+
+-- | Dimensional values inhabit this class, which allows access to a term-level representation of their dimension.
+class HasDimension a where 
+  -- | Obtains a term-level representation of a value's dimension.
+  dimension :: a -> Dimension'
+
+instance HasDimension Dimension' where
+  dimension = id
+
+-- | Converts a dimension to a list of 7 integers, representing the exponent associated with each
+-- of the 7 SI base dimensions in the standard order.
+asList :: Dimension' -> [Int]
+asList (Dim' l m t i th n j) = [l, m, t, i, th, n, j]

--- a/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
@@ -1,11 +1,29 @@
 {-# OPTIONS_HADDOCK not-home, show-extensions #-}
+
+{- |
+   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   License    : BSD3
+
+   Maintainer : bjorn@buckwalter.se
+   Stability  : Stable
+   Portability: GHC only
+
+This module defines physical dimensions expressed in terms of
+the SI base dimensions, including arithmetic.
+
+-}
 module Numeric.Units.Dimensional.DK.Dimensions.TermLevel
 (
+  -- * Type
   Dimension'(..),
+  -- * Access to Dimension of Dimensional Values
   HasDimension(..),
+  -- * Dimension Arithmetic
+  (*), (/), (^), recip,
+  -- * Synonyms for Base Dimensions
   dOne,
   dLength, dMass, dTime, dElectricCurrent, dThermodynamicTemperature, dAmountOfSubstance, dLuminousIntensity,
-  (*), (/), (^), recip,
+  -- * Deconstruction
   asList
 )
 where

--- a/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TermLevel.hs
@@ -5,12 +5,13 @@ module Numeric.Units.Dimensional.DK.Dimensions.TermLevel
   HasDimension(..),
   dOne,
   dLength, dMass, dTime, dElectricCurrent, dThermodynamicTemperature, dAmountOfSubstance, dLuminousIntensity,
-  (*), (/), recip,
+  (*), (/), (^), recip,
   asList
 )
 where
 
-import Prelude hiding ((*), (/), recip)
+import Prelude hiding ((*), (/), (^), recip)
+import qualified Prelude as P
 
 -- | A physical dimension, encoded as 7 integers, representing a factorization of the dimension into the
 -- 7 SI base dimensions. By convention they are stored in the same order as 
@@ -51,6 +52,10 @@ dLuminousIntensity        = Dim' 0 0 0 0 0 0 1
 -- | Forms the quotient of two dimensions.
 (/) :: Dimension' -> Dimension' -> Dimension'
 (Dim' l m t i th n j) / (Dim' l' m' t' i' th' n' j') = Dim' (l - l') (m - m') (t - t') (i - i') (th - th') (n - n') (j - j')
+
+-- | Raises a dimension to an integer power.
+(^) :: Dimension' -> Int -> Dimension'
+(Dim' l m t i th n j) ^ x = Dim' (x P.* l) (x P.* m) (x P.* t) (x P.* i) (x P.* th) (x P.* n) (x P.* j)
 
 -- | Forms the reciprocal of a dimension.
 recip :: Dimension' -> Dimension'

--- a/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
@@ -9,12 +9,29 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
+{- |
+   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   License    : BSD3
+
+   Maintainer : bjorn@buckwalter.se
+   Stability  : Stable
+   Portability: GHC only
+
+This module defines type-level physical dimensions expressed in terms of
+the SI base dimensions using 'Numeric.NumType.DK.NumType' for type-level integers.
+
+Type-level arithmetic, synonyms for the base dimensions, and conversion to the term-level are included.
+-}
 module Numeric.Units.Dimensional.DK.Dimensions.TypeLevel
 (
+  -- * Kind of Type-Level Dimensions
   type Dimension(..),
+  -- * Dimension Arithmetic
+  type (*), type (/), type (^), type Recip, type Root,
+  -- * Synonyms for Base Dimensions
   DOne,
   DLength, DMass, DTime, DElectricCurrent, DThermodynamicTemperature, DAmountOfSubstance, DLuminousIntensity,
-  type (*), type (/), type (^), type Recip, type Root,
+  -- * Conversion to Term Level
   type KnownDimension
 )
 where
@@ -42,6 +59,7 @@ import Numeric.Units.Dimensional.DK.Dimensions.TermLevel
 -- For the equivalent term-level representation, see 'Dimension''
 data Dimension = Dim NumType NumType NumType NumType NumType NumType NumType
 
+-- | The type-level dimensions of dimensionless values.
 type DOne                      = 'Dim 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero
 type DLength                   = 'Dim 'Pos1 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero
 type DMass                     = 'Dim 'Zero 'Pos1 'Zero 'Zero 'Zero 'Zero 'Zero
@@ -95,6 +113,9 @@ type family Root (d::Dimension) (x::NumType) where
 
 -- | A KnownDimension is one for which we can construct a term-level representation.
 -- Each validly constructed type of kind 'Dimension' has a 'KnownDimension' instance.
+--
+-- While 'KnownDimension' is a constraint synonym, the presence of @'KnownDimension' d@ in
+--  a context allows use of @'dimension' :: 'Proxy' d -> 'Dimension''@.
 type KnownDimension (d :: Dimension) = HasDimension (Proxy d)
 
 instance ( KnownNumType l

--- a/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
@@ -69,6 +69,15 @@ type DThermodynamicTemperature = 'Dim 'Zero 'Zero 'Zero 'Zero 'Pos1 'Zero 'Zero
 type DAmountOfSubstance        = 'Dim 'Zero 'Zero 'Zero 'Zero 'Zero 'Pos1 'Zero
 type DLuminousIntensity        = 'Dim 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero 'Pos1
 
+{-
+We will reuse the operators and function names from the Prelude.
+To prevent unpleasant surprises we give operators the same fixity
+as the Prelude.
+-}
+
+infixr 8  ^
+infixl 7  *, /
+
 -- | Multiplication of dimensions corresponds to adding of the base
 -- dimensions' exponents.
 type family (a::Dimension) * (b::Dimension) where

--- a/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
@@ -1,0 +1,109 @@
+{-# OPTIONS_HADDOCK not-home, show-extensions #-}
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Numeric.Units.Dimensional.DK.Dimensions.TypeLevel
+where
+
+import Data.Proxy
+import Numeric.NumType.DK
+  ( NumType (Zero, Pos1), (+)(), (-)()
+  , KnownNumType, toNum
+  )
+import qualified Numeric.NumType.DK as N
+import Numeric.Units.Dimensional.DK.Dimensions.TermLevel
+
+-- | Represents a physical dimension in the basis of the 7 SI base dimensions, 
+-- where the respective dimensions are represented by type variables
+-- using the following convention.
+--
+--  * l: Length
+--  * m: Mass
+--  * t: Time
+--  * i: Electric current
+--  * th: Thermodynamic temperature
+--  * n: Amount of substance
+--  * j: Luminous intensity
+--
+-- For the equivalent term-level representation, see 'Dimension''
+data Dimension = Dim NumType NumType NumType NumType NumType NumType NumType
+
+type DOne                      = 'Dim 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero
+type DLength                   = 'Dim 'Pos1 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero
+type DMass                     = 'Dim 'Zero 'Pos1 'Zero 'Zero 'Zero 'Zero 'Zero
+type DTime                     = 'Dim 'Zero 'Zero 'Pos1 'Zero 'Zero 'Zero 'Zero
+type DElectricCurrent          = 'Dim 'Zero 'Zero 'Zero 'Pos1 'Zero 'Zero 'Zero
+type DThermodynamicTemperature = 'Dim 'Zero 'Zero 'Zero 'Zero 'Pos1 'Zero 'Zero
+type DAmountOfSubstance        = 'Dim 'Zero 'Zero 'Zero 'Zero 'Zero 'Pos1 'Zero
+type DLuminousIntensity        = 'Dim 'Zero 'Zero 'Zero 'Zero 'Zero 'Zero 'Pos1
+
+-- | Multiplication of dimensions corresponds to adding of the base
+-- dimensions' exponents.
+type family (a::Dimension) * (b::Dimension) where
+  DOne * d = d
+  d * DOne = d
+  ('Dim l  m  t  i  th  n  j) * ('Dim l' m' t' i' th' n' j')
+    = 'Dim (l + l') (m + m') (t + t') (i + i') (th + th') (n + n') (j + j')
+
+-- | Division of dimensions corresponds to subtraction of the base
+-- dimensions' exponents.
+type family (a::Dimension) / (d::Dimension) where
+  d / DOne = d
+  d / d = DOne
+  ('Dim l  m  t  i  th  n  j) / ('Dim l' m' t' i' th' n' j')
+    = 'Dim (l - l') (m - m') (t - t') (i - i') (th - th') (n - n') (j - j')
+
+-- | The reciprocal of a dimension is defined as the result of dividing 'DOne' by it,
+-- or of negating each of the base dimensions' exponents.
+type Recip (d :: Dimension) = DOne / d
+
+-- | Powers of dimensions corresponds to multiplication of the base
+-- dimensions' exponents by the exponent.
+-- 
+-- We limit ourselves to integer powers of Dimensionals as fractional
+-- powers make little physical sense.
+type family (d::Dimension) ^ (x::NumType) where
+  DOne ^ x = DOne
+  d ^ 'Zero = DOne
+  d ^ 'Pos1 = d
+  ('Dim l  m  t  i  th  n  j) ^ x
+    = 'Dim (l N.* x) (m N.* x) (t N.* x) (i N.* x) (th N.* x) (n N.* x) (j N.* x)
+
+-- | Roots of dimensions corresponds to division of the base dimensions'
+-- exponents by the order(?) of the root.
+-- 
+-- See 'sqrt', 'cbrt', and 'nroot' for the corresponding term-level operations.
+type family Root (d::Dimension) (x::NumType) where
+  Root DOne x = DOne
+  Root d 'Pos1 = d
+  Root ('Dim l  m  t  i  th  n  j) x
+    = 'Dim (l N./ x) (m N./ x) (t N./ x) (i N./ x) (th N./ x) (n N./ x) (j N./ x)
+
+-- | A KnownDimension is one for which we can construct a term-level representation.
+-- Each validly constructed type of kind 'Dimension' has a 'KnownDimension' instance.
+type KnownDimension (d :: Dimension) = HasDimension (Proxy d)
+
+instance ( KnownNumType l
+         , KnownNumType m
+         , KnownNumType t
+         , KnownNumType i
+         , KnownNumType th
+         , KnownNumType n
+         , KnownNumType j
+         ) => HasDimension (Proxy ('Dim l m t i th n j))
+  where 
+    dimension _ = Dim'
+                (toNum (Proxy :: Proxy l))
+                (toNum (Proxy :: Proxy m))
+                (toNum (Proxy :: Proxy t))
+                (toNum (Proxy :: Proxy i))
+                (toNum (Proxy :: Proxy th))
+                (toNum (Proxy :: Proxy n))
+                (toNum (Proxy :: Proxy j))

--- a/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
+++ b/Numeric/Units/Dimensional/DK/Dimensions/TypeLevel.hs
@@ -10,6 +10,13 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Numeric.Units.Dimensional.DK.Dimensions.TypeLevel
+(
+  type Dimension(..),
+  DOne,
+  DLength, DMass, DTime, DElectricCurrent, DThermodynamicTemperature, DAmountOfSubstance, DLuminousIntensity,
+  type (*), type (/), type (^), type Recip, type Root,
+  type KnownDimension
+)
 where
 
 import Data.Proxy

--- a/dimensional-dk.cabal
+++ b/dimensional-dk.cabal
@@ -34,7 +34,10 @@ Exposed-Modules:     Numeric.Units.Dimensional.DK,
                      Numeric.Units.Dimensional.DK.Prelude,
                      Numeric.Units.Dimensional.DK.Quantities,
                      Numeric.Units.Dimensional.DK.SIUnits,
-                     Numeric.Units.Dimensional.DK.NonSI
+                     Numeric.Units.Dimensional.DK.NonSI,
+                     Numeric.Units.Dimensional.DK.Dimensions,
+                     Numeric.Units.Dimensional.DK.Dimensions.TermLevel,
+                     Numeric.Units.Dimensional.DK.Dimensions.TypeLevel
 Extra-source-files:  README.md,
                      Test.hs,
                      Numeric/Units/Dimensional/DK/Test.hs,


### PR DESCRIPTION
Sneak preview of #53, implemented in the context where #59 is accepted.

Still needs some module documentation before it should be merged, but this is a demonstration that the concept is sound, and that it imposes no API change on users of Numeric.Units.Dimensional.DK, whose export list remains completely unchanged.

Even the haddocks for Numeric.Units.Dimensional.DK remain unchanged, thanks to `{-# OPTIONS_HADDOCK not-home #-}` in the new modules, which hints to the haddock compiler that we would prefer to have links in other modules to these declarations go to Numeric.Units.Dimensional.DK and not to these new modules, which will only be directly imported for niche purposes by advanced users.