### PR TITLE
Strengthened the role of the variant type parameter.

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -282,6 +283,7 @@ way to declare quantities as such a product.
 --
 -- Since 'a' is the only non-phantom type we were able to define
 -- 'Dimensional' as a newtype, avoiding boxing at runtime.
+type role Dimensional nominal phantom representational
 newtype Dimensional (v::Variant) (d::Dimension) a
       = Dimensional a deriving (Eq, Ord, Enum, Typeable)
 


### PR DESCRIPTION
Strengthened the role of the `Variant` type parameter of `Dimensional` from the inferred `phantom` to `nominal`. This preserves our options for introducing named units, which require this stronger role. All it means is that you can't `Data.Coerce.coerce` from `Quantity d a` to `Unit d a` or vice versa.